### PR TITLE
Feat: Authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,3 +105,5 @@ group :test do
 end
 
 gem 'sendgrid-ruby', '~> 6.6'
+
+gem "cancancan", "~> 1.9"

--- a/Gemfile
+++ b/Gemfile
@@ -106,4 +106,4 @@ end
 
 gem 'sendgrid-ruby', '~> 6.6'
 
-gem "cancancan", "~> 1.9"
+gem 'cancancan', '~> 1.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
     bootsnap (1.10.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    cancancan (1.17.0)
     capybara (3.36.0)
       addressable
       matrix
@@ -282,6 +283,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  cancancan (~> 1.9)
   capybara
   debug
   devise

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,6 @@
  *= require_tree .
  *= require_self
  */
+.button_to {
+  display: inline-block;
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,13 +8,23 @@ class CommentsController < ApplicationController
   def create
     @current_user = current_user
     @post_id = params[:post_id]
+    @post = Post.find(@post_id)
     comment = Comment.new(comment_params.merge(user: @current_user, post_id: @post_id))
     if comment.save
-      redirect_to user_post_path(@current_user.id, @post_id), success: 'Your comment was successfully posted!'
+      redirect_to user_post_path(@post.id, @post_id), success: 'Your comment was successfully posted!'
     else
       flash.now[:danger] = 'Your comment was not posted!'
       render :new
     end
+  end
+
+  def destroy
+    @current_user = current_user
+    @post_id = params[:post_id]
+    @post = Post.find(@post_id)
+    @comment = Comment.find(params[:id])
+    @comment.destroy
+    redirect_to user_post_path(@post.user_id, @post_id), success: 'Your comment was successfully deleted!'
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
 
   def index
     @current_user = current_user
@@ -34,6 +34,16 @@ class PostsController < ApplicationController
       flash.now[:danger] = @post.errors.full_messages.join(', ')
       render :new
     end
+  end
+
+  def destroy
+    @current_user = current_user
+    @user = User.find_by(id: params[:user_id])
+    redirect_to users_path, danger: "No user was found by given the id: #{params[:user_id]}" if @user.nil?
+    @post = @user.posts.find_by(id: params[:id])
+    redirect_to user_posts_path(@user.id), danger: "No post was found by given id: #{params[:id]}" if @post.nil?
+    @post.destroy
+    redirect_to user_posts_path(@user.id), success: 'Post was successfully deleted'
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
 
   def index
     @current_user = current_user

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,32 @@
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    # Define abilities for the passed in user here. For example:
+    #
+    #   user ||= User.new # guest user (not logged in)
+    #   if user.admin?
+    #     can :manage, :all
+    #   else
+    #     can :read, :all
+    #   end
+    #
+    # The first argument to `can` is the action you are giving the user
+    # permission to do.
+    # If you pass :manage it will apply to every action. Other common actions
+    # here are :read, :create, :update and :destroy.
+    #
+    # The second argument is the resource the user can perform the action on.
+    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
+    # class of the resource.
+    #
+    # The third argument is an optional hash of conditions to further filter the
+    # objects.
+    # For example, here the user can only update published articles.
+    #
+    #   can :update, Article, :published => true
+    #
+    # See the wiki for details:
+    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,14 +2,13 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-
-      user ||= User.new # guest user (not logged in)
-      can :read, :all
-      if user.is? :admin
-        can :manage, :all
-      elsif user.is? :user
-        can :manage, Post, user_id: user.id
-        can :manage, Comment, user_id: user.id
-      end
+    user ||= User.new # guest user (not logged in)
+    can :read, :all
+    if user.is? :admin
+      can :manage, :all
+    elsif user.is? :user
+      can :manage, Post, user_id: user.id
+      can :manage, Comment, user_id: user.id
+    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -2,31 +2,14 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # Define abilities for the passed in user here. For example:
-    #
-    #   user ||= User.new # guest user (not logged in)
-    #   if user.admin?
-    #     can :manage, :all
-    #   else
-    #     can :read, :all
-    #   end
-    #
-    # The first argument to `can` is the action you are giving the user
-    # permission to do.
-    # If you pass :manage it will apply to every action. Other common actions
-    # here are :read, :create, :update and :destroy.
-    #
-    # The second argument is the resource the user can perform the action on.
-    # If you pass :all it will apply to every resource. Otherwise pass a Ruby
-    # class of the resource.
-    #
-    # The third argument is an optional hash of conditions to further filter the
-    # objects.
-    # For example, here the user can only update published articles.
-    #
-    #   can :update, Article, :published => true
-    #
-    # See the wiki for details:
-    # https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
+
+      user ||= User.new # guest user (not logged in)
+      can :read, :all
+      if user.is? :admin
+        can :manage, :all
+      elsif user.is? :user
+        can :manage, Post, user_id: user.id
+        can :manage, Comment, user_id: user.id
+      end
   end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,9 @@
 class Post < ApplicationRecord
   belongs_to :user
-  has_many :comments
-  has_many :likes
+  has_many :comments, dependent: :destroy
+  has_many :likes, dependent: :destroy
   after_save :update_post_counter
+  after_destroy :update_post_counter_after_destroy
   validates :title, presence: true, length: { maximum: 250 }
   validates :text, presence: true
   validates :comments_counter, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
@@ -16,5 +17,9 @@ class Post < ApplicationRecord
 
   def update_post_counter
     user.increment!(:posts_counter)
+  end
+
+  def update_post_counter_after_destroy
+    user.decrement!(:posts_counter)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  # rubocop:disable all
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :confirmable
@@ -10,7 +11,7 @@ class User < ApplicationRecord
 
   Roles = [ :admin , :user ]
 
-  def is?( requested_role )
+  def is?(requested_role)
     self.role == requested_role.to_s
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,11 +2,17 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :validatable, :confirmable
-  has_many :posts, class_name: 'Post'
-  has_many :likes, class_name: 'Like'
-  has_many :comments, class_name: 'Comment'
+  has_many :posts, class_name: 'Post', dependent: :destroy
+  has_many :likes, class_name: 'Like', dependent: :destroy
+  has_many :comments, class_name: 'Comment', dependent: :destroy
   validates :name, presence: true
   validates :posts_counter, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
+
+  Roles = [ :admin , :user ]
+
+  def is?( requested_role )
+    self.role == requested_role.to_s
+  end
 
   def recent_posts
     Post.where(user_id: id).order(created_at: :desc).limit(3)

--- a/app/views/application/_comment.html.erb
+++ b/app/views/application/_comment.html.erb
@@ -1,3 +1,15 @@
-<li class="list-group-item border-bottom-0">
-  <%= comment.user.name %>: <%= comment.text %>
+<li class="list-group-item card">
+  <div class="card-header d-flex align-items-center gap-2">
+    <%= comment.user.name %>
+    <small>
+      <%= comment.created_at.strftime("%m/%d/%Y %I:%M %p") %>
+    </small>
+
+    <% if can? :destroy, comment %>
+    <div class="ms-auto d-inline-block"> 
+      <%= button_to "", user_post_comment_path(comment.user_id,comment.post_id,comment.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-danger fa-solid fa-trash-can d-inline-block ms-auto' %>
+    </div>
+    <% end %>
+  </div>
+  <div class="card-body"><%= comment.text %></div>
 </li>

--- a/app/views/application/_like_comment_links.html.erb
+++ b/app/views/application/_like_comment_links.html.erb
@@ -1,4 +1,4 @@
-<%= button_to user_post_likes_path(user.id, post.id), method: :post, class: "fa fa-thumbs-up me-2 text-decoration-none border-0 text-primary" do %>
+<%= button_to user_post_likes_path(user.id, post.id), method: :post, class: "fa fa-thumbs-up me-2 text-decoration-none border-0 text-primary bg-transparent" do %>
 <% end %>
 <%= link_to new_user_post_comment_path(user.id, post.id), class: "fa-comment fa-solid text-decoration-none" do %>
 <% end %>

--- a/app/views/application/_post.html.erb
+++ b/app/views/application/_post.html.erb
@@ -1,9 +1,15 @@
 <article class="card" >
   <%= link_to user_post_path(@user.id, post.id), class: "text-decoration-none" do %>
-    <div class="card-header">
+    <div class="card-header d-flex">
       <h3>
         <%= post.title %>
       </h3>
+
+      <% if can? :destroy, post %>
+        <div class="ms-auto d-inline-block"> 
+          <%= button_to "", user_post_path(post.user_id,post.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-danger fa-solid fa-trash-can d-inline-block ms-auto' %>
+        </div>
+      <% end %>
     </div>
     <div class="card-body">
       <p class="card-text">

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -5,7 +5,7 @@
 
   <div class="mb-3">
     <%= f.label :email , class: 'form-label'%><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",, class: 'form-control' value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: 'form-control', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
   </div>
 
   <div class="mb-3">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -54,4 +54,4 @@
 
 <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: 'btn btn-danger mb-3'%>
 
-<%= link_to "Back", :back %>
+<%= link_to "Back", :back, class: 'd-block' %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,6 +8,13 @@
     <div>
       Comments: <%= @post.comments.count %>,
       Likes: <%= @post.likes.count %>
+
+
+      <% if can? :destroy, @post %>
+        <div class="ms-3 d-inline-block"> 
+          <%= button_to "", user_post_path(@post.user_id,@post.id), method: :delete, data: { confirm: "Are you sure?" }, class: 'btn btn-danger fa-solid fa-trash-can d-inline-block ms-auto' %>
+        </div>
+      <% end %>
     </div>
   </div>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,13 @@
       </div>
     </div>
 
-    <%= render partial: "post", collection: @posts %>
+    <div class="posts_container">
+      <% @posts.each do |post| %>
+        <%= render "post", post: post %>
+        <% post.comments.each do |comment| %>
+          <%= render "comment", comment: comment %>
+        <% end %>
+      <% end %>
+    </div>
     <%= link_to "See all posts", user_posts_path(@user.id), class: "btn btn-primary mx-auto", style: "width: fit-content" %>
 </main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Rails.application.routes.draw do
   devise_for :users
   resources :users, only: [:index, :show] do
-    resources :posts, only: [:index, :show, :new, :create] do
-      resources :comments, only: [:new, :create]
+    resources :posts, only: [:index, :show, :new, :create, :destroy] do
+      resources :comments, only: [:new, :create, :destroy]
       resources :likes, only: [:create]
     end
   end

--- a/db/migrate/20220304185933_add_role_to_user.rb
+++ b/db/migrate/20220304185933_add_role_to_user.rb
@@ -1,0 +1,5 @@
+class AddRoleToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :role, :string, default: 'user'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_03_04_131552) do
+ActiveRecord::Schema[7.0].define(version: 2022_03_04_185933) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -60,6 +60,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_03_04_131552) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.string "unconfirmed_email"
+    t.string "role", default: "user"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
In this pull request: 
Add cancancan
Add column `role`
By creating a new user its default is `user` role
I allowed users to remove a comment and a post as long as it was theirs
Admin has all permissions.
I made it by deleting a post or a user (deletes his accounts) to delete all dependents.

note: as mentioned above default `role` is user so in order to test `admin` functionality the only way is to create an account then update its role after `confirmation` from `rails c` by running
```shell
User.first.update(role: 'admin') # assuming it's the first user you created
```